### PR TITLE
Guest can join created playlist

### DIFF
--- a/app/controllers/playlist_controller.rb
+++ b/app/controllers/playlist_controller.rb
@@ -6,5 +6,6 @@ class PlaylistController < ApplicationController
 
   def show
     @playlist = Playlist.find_by(code: params[:id])
+    render file: "public/404" if @playlist.nil?
   end
 end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -1,42 +1,33 @@
 FactoryGirl.define do
   factory :playlist do
-    name "MyString"
+    name        "MyString"
     playlist_id "MyString"
-    id "MyString"
-    uri "MyString"
-    href "MyString"
-    tracks "MyString"
+    id          "MyString"
+    uri         "MyString"
+    href        "MyString"
+    tracks      "MyString"
     snapshot_id "MyString"
-    code "MyString"
+    code        "MyString"
   end
   factory :user do
-    uid "MyString"
-    image "MyString"
-    token "MyString"
+    uid           "MyString"
+    image         "MyString"
+    token         "MyString"
     refresh_token "MyString"
-    token_expiry Time.parse("2016-04-20 22:21:52.000000")
+    token_expiry  Time.parse("2016-04-20 22:21:52.000000")
   end
 end
 
 FactoryGirl.define do
   factory :user_with_playlist do
-    uid "MyString"
-    image "MyString"
-    token "MyString"
+    uid           "MyString"
+    image         "MyString"
+    token         "MyString"
     refresh_token "MyString"
-    token_expiry Time.parse("2016-04-20 22:21:52.000000")
+    token_expiry  Time.parse("2016-04-20 22:21:52.000000")
 
     after (:build) do |playlist|
-      user.playlists << FactoryGirl.create(:playlist,
-        user: user,
-        # name: "MyString",
-        # playlist_id: "MyString",
-        # id: "MyString",
-        # uri: "MyString",
-        # href: "MyString",
-        # tracks: "MyString",
-        # snapshot_id: "MyString"
-      )
+      user.playlists << FactoryGirl.create(:playlist, user: user)
     end
   end
 end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -1,12 +1,13 @@
 FactoryGirl.define do
   factory :playlist do
     name "MyString"
+    playlist_id "MyString"
     id "MyString"
     uri "MyString"
     href "MyString"
     tracks "MyString"
     snapshot_id "MyString"
-    user 1
+    code "MyString"
   end
   factory :user do
     uid "MyString"
@@ -14,5 +15,28 @@ FactoryGirl.define do
     token "MyString"
     refresh_token "MyString"
     token_expiry Time.parse("2016-04-20 22:21:52.000000")
+  end
+end
+
+FactoryGirl.define do
+  factory :user_with_playlist do
+    uid "MyString"
+    image "MyString"
+    token "MyString"
+    refresh_token "MyString"
+    token_expiry Time.parse("2016-04-20 22:21:52.000000")
+
+    after (:build) do |playlist|
+      user.playlists << FactoryGirl.create(:playlist,
+        user: user,
+        # name: "MyString",
+        # playlist_id: "MyString",
+        # id: "MyString",
+        # uri: "MyString",
+        # href: "MyString",
+        # tracks: "MyString",
+        # snapshot_id: "MyString"
+      )
+    end
   end
 end

--- a/spec/features/guest_can_join_created_playlist_spec.rb
+++ b/spec/features/guest_can_join_created_playlist_spec.rb
@@ -1,0 +1,16 @@
+require "rails_helper"
+
+RSpec.feature "Guest can join created playlist" do
+  scenario "they see the playlist page for that playlist" do
+      playlist = create(:playlist)
+      playlist.update(code: "xyz")
+
+      visit "/playlist/xyz"
+
+      expect(current_path).to eq(playlist_path(playlist.code))
+      expect(page).to have_content("Search Spotify")
+      within(".playlist-code") do
+        expect(page).to have_content("Your Playlist Code is: #{playlist.code}")
+    end
+  end
+end

--- a/spec/features/guest_can_join_created_playlist_spec.rb
+++ b/spec/features/guest_can_join_created_playlist_spec.rb
@@ -2,15 +2,22 @@ require "rails_helper"
 
 RSpec.feature "Guest can join created playlist" do
   scenario "they see the playlist page for that playlist" do
-      playlist = create(:playlist)
-      playlist.update(code: "xyz")
+    playlist = create(:playlist)
+    playlist.update(code: "xyz")
 
-      visit "/playlist/xyz"
+    visit "/playlist/xyz"
 
-      expect(current_path).to eq(playlist_path(playlist.code))
-      expect(page).to have_content("Search Spotify")
-      within(".playlist-code") do
-        expect(page).to have_content("Your Playlist Code is: #{playlist.code}")
+    expect(current_path).to eq(playlist_path(playlist.code))
+    expect(page).to have_content("Search Spotify")
+    within(".playlist-code") do
+      expect(page).to have_content("Your Playlist Code is: #{playlist.code}")
     end
+  end
+
+  scenario "they see a 404 if trying a playlist not created" do
+    visit "/playlist/foobar"
+
+    expect(page).to have_content("404")
+    expect(page).to_not have_content("Your Playlist Code is: foobar")
   end
 end

--- a/spec/features/user_can_start_a_new_playlist_spec.rb
+++ b/spec/features/user_can_start_a_new_playlist_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.feature "Creating a playlist" do
   scenario "user can create a new playlist" do
     VCR.use_cassette("create_a_playlist") do
-      user = create_authorized_user
+      user = create_authenticated_user
       allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
 
       visit root_path

--- a/spec/models/spotify_user_service_spec.rb
+++ b/spec/models/spotify_user_service_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe SpotifyUserService, type: :service do
   it "creates a playlist" do
     VCR.use_cassette('create a playlist') do
 
-      user = create_authorized_user
+      user = create_authenticated_user
       service = SpotifyUserService.new(user)
       name = Time.now.strftime('%Y%m%d')
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -99,7 +99,7 @@ def stub_omniauth
   )
 end
 
-def create_authorized_user
+def create_authenticated_user
   user = User.create(uid: "mingus_amongus",
               image: "https://scontent.xx.fbcdn.net/hprofile-xap1/v/t1.0-1/249783_930132649627_927852406_n.jpg?oh=c79ea044bf0027f57b817bd734b46438&oe=57B11642",
               token: "BQA5YhFv63_InK4mlc3TDFZLfT9FOUY-otWJS0yd07AFE_NpPSKLa-nFq5rji7m4Gy01YyFAtgqIIk4h1D-FGa4fJGQyng6AARk_5FiuOQ5OJDWergduAnZHYa5U0v4ed7rtRK1ykx9nfRaAea65SRhUW9T7NtzIupo86rWvUk45YXlOE0sH_a-rpuMPXmkrPYAQc6UvNZCCxXzW4w14Y4wr9AJ5QQQhHZO6",


### PR DESCRIPTION
Tested ability of a guest to join a created playlist without needing to sign in to spotify.
Also added a sad path, if someone tries to navigate to a playlist that has not been created, a 404 page is rendered.

closes #6
