### PR TITLE
Fix track reorder bug

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -37,3 +37,7 @@ group :test do
   gem 'capybara-webkit'
   gem 'database_cleaner'
 end
+
+group :production do
+  gem "rails_12factor"
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -154,6 +154,11 @@ GEM
       rails-deprecated_sanitizer (>= 1.0.1)
     rails-html-sanitizer (1.0.3)
       loofah (~> 2.0)
+    rails_12factor (0.0.3)
+      rails_serve_static_assets
+      rails_stdout_logging
+    rails_serve_static_assets (0.0.5)
+    rails_stdout_logging (0.0.5)
     railties (4.2.5.1)
       actionpack (= 4.2.5.1)
       activesupport (= 4.2.5.1)
@@ -254,6 +259,7 @@ DEPENDENCIES
   pry
   quiet_assets
   rails (= 4.2.5.1)
+  rails_12factor
   rspec-rails (~> 3.0)
   sass-rails (~> 5.0)
   sdoc (~> 0.4.0)

--- a/app/controllers/playlist_controller.rb
+++ b/app/controllers/playlist_controller.rb
@@ -9,7 +9,6 @@ class PlaylistController < ApplicationController
 
   def show
     @playlist = Playlist.find_by(code: params[:id])
-    @playlist.reorder_tracks_by_votes
     render file: "public/404" if @playlist.nil?
   end
 

--- a/app/models/playlist.rb
+++ b/app/models/playlist.rb
@@ -19,12 +19,6 @@ class Playlist < ActiveRecord::Base
     end
   end
 
-  def reorder_tracks_by_votes
-    playlist_tracks.includes(:votes)
-      .group("playlist_tracks.id")
-      .order("votes.count DESC")
-  end
-
   def generate_code
     while self.code.nil? do
       code = CodeGenerator.generate_playlist_code

--- a/app/models/playlist_track.rb
+++ b/app/models/playlist_track.rb
@@ -8,4 +8,10 @@ class PlaylistTrack < ActiveRecord::Base
   def vote_count
     votes.count
   end
+
+  def self.reorder_tracks_by_votes
+    joins(:votes)
+      .group("playlist_tracks.id")
+      .order("votes.count DESC")
+  end
 end

--- a/app/views/playlist/show.html.erb
+++ b/app/views/playlist/show.html.erb
@@ -18,7 +18,7 @@
             </tr>
             </thead>
             <tbody>
-              <% @playlist.playlist_tracks.each_with_index do |playlist_track, i| %>
+              <% @playlist.playlist_tracks.reorder_tracks_by_votes.each_with_index do |playlist_track, i| %>
               <tr>
                 <div class="track-<%= i + 1 %>">
                   <td><%= i + 1%></td>


### PR DESCRIPTION
Previously the voting/reorder logic wasn't functioning properly. The activerecord querying was moved to the playlist tracks model as an instance method, and called when playlist tracks are presented on the show view. 
