### PR TITLE
Fix big with duplicate playlist tracks

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -77,8 +77,6 @@ a:hover {
   background-color: #fff;
   border: .05rem solid #fff;
 }
-
-
 /*
  * Base structure
  */
@@ -91,7 +89,6 @@ body {
 body {
   color: #fff;
   text-align: center;
-  text-shadow: 0 .05rem .1rem rgba(0,0,0,.5);
 }
 
 /* Extra markup and styles for table-esque vertical and horizontal centering */

--- a/app/controllers/playlist_controller.rb
+++ b/app/controllers/playlist_controller.rb
@@ -14,13 +14,14 @@ class PlaylistController < ApplicationController
 
   def add_track
     playlist = Playlist.find_by(code: params[:track][:code])
-    if track = playlist.tracks.create(track_params(params))
-      pt = PlaylistTrack.where(playlist_id: playlist.id, track_id: track.id).first
-      pt.votes.create(token: session[:token])
+    track = Track.where(uri: params[:track][:uri]).first_or_create(track_params(params))
+    playlist_track = PlaylistTrack.new(playlist_id: playlist.id, track_id: track.id)
+    if playlist_track.save
+      playlist_track.votes.create(token: session[:token])
       redirect_to playlist_path(playlist.code)
     else
-      flash.now[:danger] = "That song is already on the playlist"
-      render :show
+      flash[:danger] = "That song is already on the playlist"
+      redirect_to playlist_path(playlist)
     end
   end
 

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -3,7 +3,7 @@ class SessionsController < ApplicationController
     if user = User.from_omniauth(request.env["omniauth.auth"])
       session[:uid] = user.uid
     else
-      flash[:errors] = "There was a problem signing in."
+      flash[:danger] = "There was a problem signing in."
     end
     redirect_to root_path
   end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -8,6 +8,9 @@
   <meta name="viewport" content="width=device-width, initial-scale=1"></head>
 <body>
 <%= render partial: "shared/navbar" %>
+<% flash.each do |name, msg| %>
+  <%= content_tag :div, msg, class: "alert alert-#{name}" %>
+<% end %>
 <%= yield %>
 
 </body>


### PR DESCRIPTION
When a track is added it is either found or created with the
tracks table. Then, a new playlist track is made. If the playlist track doesn't
save, the user sees an error - indicating a duplicate track.

This fixes a previous bug that caused a 500 error.

closes #30 
